### PR TITLE
取消光标列高亮，增加光标移到屏幕顶部和底部的命令

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -44,7 +44,7 @@ set tm=500
 
 
 " show location
-set cursorcolumn
+"set cursorcolumn
 set cursorline
 
 

--- a/vimrc
+++ b/vimrc
@@ -44,7 +44,7 @@ set tm=500
 
 
 " show location
-set cursorcolumn
+"set cursorcolumn
 set cursorline
 
 
@@ -243,6 +243,8 @@ map Y y$
 nnoremap ; :
 
 " Shift+H goto head of the line, Shift+L goto end of the line
+nnoremap J L
+nnoremap K H
 nnoremap H ^
 nnoremap L $
 

--- a/vimrc
+++ b/vimrc
@@ -194,7 +194,20 @@ nnoremap <F4> :set wrap! wrap?<CR>
 set pastetoggle=<F5>            "    when in insert mode, press <F5> to go to
                                 "    paste mode, where you can paste mass data
                                 "    that won't be autoindented
+
+" disbale paste mode when leaving insert mode
 au InsertLeave * set nopaste
+
+" F5 set paste问题已解决, 粘贴代码前不需要按F5了
+" F5 粘贴模式paste_mode开关,用于有格式的代码粘贴
+" Automatically set paste mode in Vim when pasting in insert mode
+function! XTermPasteBegin()
+  set pastetoggle=<Esc>[201~
+  set paste
+  return ""
+endfunction
+inoremap <special> <expr> <Esc>[200~ XTermPasteBegin()
+
 nnoremap <F6> :exec exists('syntax_on') ? 'syn off' : 'syn on'<CR>
 
 " kj 替换 Esc

--- a/vimrc
+++ b/vimrc
@@ -55,7 +55,7 @@ set scrolloff=7                 " keep 3 lines when scrolling
 " show
 set ruler                       " show the current row and column
 set number                      " show line numbers
-set nowrap
+"set nowrap
 set showcmd                     " display incomplete commands
 set showmode                    " display current modes
 set showmatch                   " jump to matches when entering parentheses
@@ -204,6 +204,8 @@ inoremap kj <Esc>
 nnoremap <leader>q :q<CR>
 " Quickly save the current file
 nnoremap <leader>w :w<CR>
+" Quickly save and quit
+nnoremap <leader>x :x<CR>
 
 " select all
 map <Leader>sa ggVG"

--- a/vimrc
+++ b/vimrc
@@ -182,6 +182,8 @@ nnoremap k gk
 nnoremap gk k
 nnoremap j gj
 nnoremap gj j
+nnoremap gh ^
+nnoremap gl $
 
 map <C-j> <C-W>j
 map <C-k> <C-W>k
@@ -260,8 +262,8 @@ nnoremap ; :
 " Shift+H goto head of the line, Shift+L goto end of the line
 nnoremap J L
 nnoremap K H
-nnoremap H ^
-nnoremap L $
+nnoremap H g^
+nnoremap L g$
 
 " save
 cmap w!! w !sudo tee >/dev/null %


### PR DESCRIPTION
光标列高亮，会严重影响代码阅读，所以取消。（注释掉了，如果需要可以取消注释）

原来的版本中，H 被替换成了移到行首，L 被替换成了移到行尾。这样一来就缺少了移到屏幕顶部和屏幕尾部的命令。由于 J 和 K 不常用，且 j 和 k 与行移动有关，使用时，常用的逻辑是：光标移到屏幕顶部之后紧接着向上移动；光标移到屏幕底部之后紧接着向下移动。正好与 k 和 j 命令连用。所以这样定义：
J       光标移到屏幕底部
K      光标移到屏幕顶部