### PR TITLE
修改一些按键和显示

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -44,7 +44,7 @@ set tm=500
 
 
 " show location
-set cursorcolumn
+"set cursorcolumn
 set cursorline
 
 
@@ -55,7 +55,7 @@ set scrolloff=7                 " keep 3 lines when scrolling
 " show
 set ruler                       " show the current row and column
 set number                      " show line numbers
-set nowrap
+"set nowrap
 set showcmd                     " display incomplete commands
 set showmode                    " display current modes
 set showmatch                   " jump to matches when entering parentheses
@@ -182,6 +182,8 @@ nnoremap k gk
 nnoremap gk k
 nnoremap j gj
 nnoremap gj j
+nnoremap gh ^
+nnoremap gl $
 
 map <C-j> <C-W>j
 map <C-k> <C-W>k
@@ -194,7 +196,20 @@ nnoremap <F4> :set wrap! wrap?<CR>
 set pastetoggle=<F5>            "    when in insert mode, press <F5> to go to
                                 "    paste mode, where you can paste mass data
                                 "    that won't be autoindented
+
+" disbale paste mode when leaving insert mode
 au InsertLeave * set nopaste
+
+" F5 set paste问题已解决, 粘贴代码前不需要按F5了
+" F5 粘贴模式paste_mode开关,用于有格式的代码粘贴
+" Automatically set paste mode in Vim when pasting in insert mode
+function! XTermPasteBegin()
+  set pastetoggle=<Esc>[201~
+  set paste
+  return ""
+endfunction
+inoremap <special> <expr> <Esc>[200~ XTermPasteBegin()
+
 nnoremap <F6> :exec exists('syntax_on') ? 'syn off' : 'syn on'<CR>
 
 " kj 替换 Esc
@@ -204,6 +219,8 @@ inoremap kj <Esc>
 nnoremap <leader>q :q<CR>
 " Quickly save the current file
 nnoremap <leader>w :w<CR>
+" Quickly save and quit
+nnoremap <leader>x :x<CR>
 
 " select all
 map <Leader>sa ggVG"
@@ -243,8 +260,10 @@ map Y y$
 nnoremap ; :
 
 " Shift+H goto head of the line, Shift+L goto end of the line
-nnoremap H ^
-nnoremap L $
+nnoremap J L
+nnoremap K H
+nnoremap H g^
+nnoremap L g$
 
 " save
 cmap w!! w !sudo tee >/dev/null %


### PR DESCRIPTION
>     H   wrap 模式下，光标移动到屏幕中显示的行首，而不是整行行首
>     L   wrap 模式下，光标移动到屏幕中显示的行尾，而不是整行行尾
>     gh  光标移动到整行行首
>     gl  光标移动到整行行尾
>     J   光标移动到本页最下面一行，好处：可以方便地与 j 命令连用
>     K   光标移动到本页最上面一行，好处：可以方便地与 k 命令连用

>     ,x  同 :wq 或 :x ，快速保存并退出

>     取消光标所在列的高亮，这样阅读时不容易挡视线
>     开启 wrap 模式，这样比 nowrap 模式可读性更强，此好处尤其体现在需要用鼠标复制的时候